### PR TITLE
修复 Shizuku 安装方法

### DIFF
--- a/app/src/main/java/com/modosa/apkinstaller/util/IOUtils.java
+++ b/app/src/main/java/com/modosa/apkinstaller/util/IOUtils.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 public class IOUtils {
     private static final String TAG = "IOUtils";
@@ -17,6 +19,19 @@ public class IOUtils {
         while ((len = from.read(buf)) > 0) {
             to.write(buf, 0, len);
         }
+    }
+
+
+    public static String toString(InputStream inputStream) throws IOException {
+        final int bufferSize = 1024;
+        final char[] buffer = new char[bufferSize];
+        final StringBuilder out = new StringBuilder();
+        Reader in = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+        int charsRead;
+        while ((charsRead = in.read(buffer, 0, buffer.length)) > 0) {
+            out.append(buffer, 0, charsRead);
+        }
+        return out.toString();
     }
 
 

--- a/app/src/main/java/com/modosa/apkinstaller/util/IOUtils.java
+++ b/app/src/main/java/com/modosa/apkinstaller/util/IOUtils.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 
 public class IOUtils {
     private static final String TAG = "IOUtils";
@@ -20,20 +18,6 @@ public class IOUtils {
             to.write(buf, 0, len);
         }
     }
-
-
-    public static String toString(InputStream inputStream) throws IOException {
-        final int bufferSize = 1024;
-        final char[] buffer = new char[bufferSize];
-        final StringBuilder out = new StringBuilder();
-        Reader in = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-        int charsRead;
-        while ((charsRead = in.read(buffer, 0, buffer.length)) > 0) {
-            out.append(buffer, 0, charsRead);
-        }
-        return out.toString();
-    }
-
 
     public static Thread writeStreamToStringBuilder(StringBuilder builder, InputStream inputStream) {
         Thread t = new Thread(() -> {

--- a/app/src/main/java/com/modosa/apkinstaller/util/installer/ShellSAIPackageInstaller.java
+++ b/app/src/main/java/com/modosa/apkinstaller/util/installer/ShellSAIPackageInstaller.java
@@ -83,7 +83,12 @@ public abstract class ShellSAIPackageInstaller extends SAIPackageInstaller {
                     installationCompleted();
                     return;
                 }
-                ensureCommandSucceeded(getShell().exec(new Shell.Command("pm", "install-write", "-S", String.valueOf(apkSource.getApkLength()), String.valueOf(sessionId), String.format("%d.apk", currentApkFile++)), apkSource.openApkInputStream()));
+                ensureCommandSucceeded(getShell().exec(
+                        new Shell.Command("pm", "install-write", "-S",
+                                String.valueOf(apkSource.getApkLength()),
+                                String.valueOf(sessionId), String.format("%d.apk", currentApkFile++)),
+                        apkSource.openApkInputStream())
+                );
             }
 
             mIsAwaitingBroadcast.set(true);


### PR DESCRIPTION
修复了以下两个错误
在 Shizuku Shell 关闭后依然读取 InputStream 导致的安装中断
修复 Shizuku InputStream 功能

未完成的修复
在输入安装包字节时（使用 IOUtils#copyStream 函数）会引发语法错误，未知原因
``` shell
sh: <stdin>[1]: syntax error: unexpected ')'
```
测试用安装包（来自超微浏览器）
[a.apk.zip](https://github.com/dadaewq/Install-Lion/files/4649891/a.apk.zip)

其他建议：*Rikka 建议使用 binder 实现调用 Shizuku 接口的安装，而非 Shell*